### PR TITLE
fix `launch.sh` can't find error.

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -10,7 +10,7 @@ command=/usr/bin/x11vnc
 autorestart=true
 
 [program:noVNC]
-command=/usr/share/noVNC/utils/launch.sh --vnc localhost:5900 --listen 8083
+command=/usr/share/noVNC/utils/novnc_proxy --vnc localhost:5900 --listen 8083
 autorestart=true
 
 [program:i3]


### PR DESCRIPTION
nonvc renamed `launch.sh` to `novnc_proxy`. 
https://github.com/novnc/noVNC/issues/1670